### PR TITLE
add buffer protocol support to writePixels

### DIFF
--- a/test-exr.py
+++ b/test-exr.py
@@ -225,6 +225,17 @@ class TestDirected(unittest.TestCase):
         f.seek(0)
         self.assertEqual(hdr, OpenEXR.InputFile(f).header())
 
+    def test_write_buffer_object(self):
+        (w, h) = (640, 480)
+        a = array('f', [(i % w)/float(w) for i in range(w * h)])
+        data = bytearray(a.tobytes())
+        hdr = OpenEXR.Header(w,h)
+        x = OpenEXR.OutputFile("out3.exr", hdr)
+        x.writePixels({'R': data, 'G': data, 'B': data})
+        x.close()
+        r = self.load_red("out3.exr")
+        self.assertTrue(r == data)
+
 if __name__ == '__main__':
     if 1:
         unittest.main()


### PR DESCRIPTION
Hi,
The following pull request adds buffer protocol support to writePixels. 
https://docs.python.org/3/c-api/buffer.html
This allows objects that expose the buffer protocol to be passed directly to writePixels without needing to copy the image data to a str or bytes object.

For example, numpy arrays can be passed directly to writePixels:
```python
import numpy
import OpenEXR

pixels = numpy.random.rand(640, 480).astype(numpy.float32)
h = OpenEXR.Header(640,480)
exr = OpenEXR.OutputFile("out.exr", h)
exr.writePixels({'R': pixels, 'G': pixels, 'B': pixels})
exr.close()
```
