### PR TITLE
Add build dependencies to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,14 @@ OpenEXR bindings for Python
 
 See homepage at http://www.excamera.com/sphinx/articles-openexr.html
 
+## Requirements
+
+To build from source, a C++ compiler and libraries and development headers for OpenEXR and zlib are required. In Ubuntu, the `g++`, `libopenexr-dev` and `zlib1g-dev` packages suffice all requirements.
+
 For the latest release, run:
 
     pip install openexr
-    
+
 In case the PyPi package is not updated and you want to install from the master branch, you can do the following:
 
     pip install git+https://github.com/jamesbowman/openexrpython.git
@@ -17,5 +21,4 @@ If you prefer, you can clone it and run the `setup.py` file as well. Use the fol
 commands to get a copy from Github and do the installation:
 
     git clone https://github.com/jamesbowman/openexrpython
-    cd openexrpython
-    python3 setup.py install # installs for Python 3.xx
+    pip install ./openexrpython


### PR DESCRIPTION
As discussed in #24.

I tested under a clean Ubuntu container and it works with these packages. We can add other distros later on.

BTW, binary wheels could be pushed to pip instead of relying on users compiling the library individually. We could have wheels for the most common platforms and Python versions (e.g. 2.7 and recent 3.* versions).