### PR TITLE
Fix build issues on OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ See homepage at http://www.excamera.com/sphinx/articles-openexr.html
 
 ## Requirements
 
-To build from source, a C++ compiler and libraries and development headers for OpenEXR and zlib are required. In Ubuntu, the `g++`, `libopenexr-dev` and `zlib1g-dev` packages suffice all requirements.
+To build from source, a C++ compiler and libraries and development headers for OpenEXR and zlib are required. In Ubuntu, the `g++`, `libopenexr-dev` and `zlib1g-dev` packages suffice all requirements. In OSX, the Homebrew packages `openexr` and `zlib` will suffice.
 
 For the latest release, run:
 

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,21 @@
 from distutils.core import setup
 from distutils.extension import Extension
 from distutils.command.build_py import build_py as _build_py
-
-from os import system
+from distutils.sysconfig import get_config_var
+from distutils.version import LooseVersion
+import sys
+import os
+import platform
 
 from distutils.core import setup, Extension
+
+if sys.platform == 'darwin':
+    if 'MACOSX_DEPLOYMENT_TARGET' not in os.environ:
+        current_system = LooseVersion(platform.mac_ver()[0])
+        python_target = LooseVersion(
+            get_config_var('MACOSX_DEPLOYMENT_TARGET'))
+        if python_target < '10.9' and current_system >= '10.9':
+            os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.9'
 
 version = "1.3.2"
 setup(name='OpenEXR',
@@ -18,9 +29,9 @@ setup(name='OpenEXR',
     Extension('OpenEXR',
               ['OpenEXR.cpp'],
               include_dirs=['/usr/include/OpenEXR', '/usr/local/include/OpenEXR', '/opt/local/include/OpenEXR'],
-              library_dirs=['/usr/local/lib', '/opt/local/lib'],
+              library_dirs=['/usr/local/lib'],
               libraries=['Iex', 'Half', 'Imath', 'IlmImf', 'z'],
-              extra_compile_args=['-g', '-DVERSION="%s"' % version])
+              extra_compile_args=['-std=c++17','-g', '-DVERSION="%s"' % version])
   ],
   py_modules=['Imath'],
 )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,11 @@ import platform
 
 from distutils.core import setup, Extension
 
+version = "1.3.2"
+compiler_args = ['-g', '-DVERSION="%s"' % version]
+
 if sys.platform == 'darwin':
+    compiler_args.append('-std=c++14')
     if 'MACOSX_DEPLOYMENT_TARGET' not in os.environ:
         current_system = LooseVersion(platform.mac_ver()[0])
         python_target = LooseVersion(
@@ -17,7 +21,7 @@ if sys.platform == 'darwin':
         if python_target < '10.9' and current_system >= '10.9':
             os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.9'
 
-version = "1.3.2"
+            
 setup(name='OpenEXR',
   author = 'James Bowman',
   author_email = 'jamesb@excamera.com',
@@ -29,9 +33,9 @@ setup(name='OpenEXR',
     Extension('OpenEXR',
               ['OpenEXR.cpp'],
               include_dirs=['/usr/include/OpenEXR', '/usr/local/include/OpenEXR', '/opt/local/include/OpenEXR'],
-              library_dirs=['/usr/local/lib'],
+              library_dirs=['/usr/local/lib', '/opt/local/lib'],
               libraries=['Iex', 'Half', 'Imath', 'IlmImf', 'z'],
-              extra_compile_args=['-std=c++17','-g', '-DVERSION="%s"' % version])
+              extra_compile_args=compiler_args)
   ],
   py_modules=['Imath'],
 )


### PR DESCRIPTION
This is in reference to the errors described in #32, which was caused by the wrong standard library being used and not found by the compiler, due to python being built with an earlier version of OS X before that library was deprecated. This works around that by changing the target platform in the event that this is the case.