### PR TITLE
Fix missing include

### DIFF
--- a/OpenEXR.cpp
+++ b/OpenEXR.cpp
@@ -70,6 +70,7 @@ typedef int Py_ssize_t;
 #include <ImfTimeCodeAttribute.h>
 #include <ImfTimeCode.h>
 
+#include <algorithm>
 #include <iostream>
 #include <iomanip>
 #include <iostream>


### PR DESCRIPTION
This PR fixes a missing include that is required for using `std::min` and `std::max`. I don't know if GCC stumbles over this but at least MSVC 14.2x (Visual Studio 2019) does. It's probably nice to be explicit about the include either way.